### PR TITLE
Fix focusguards to top left of viewport

### DIFF
--- a/src/Lock.js
+++ b/src/Lock.js
@@ -8,6 +8,9 @@ const hidden = {
   height: '0px',
   padding: 0,
   overflow: 'hidden',
+  position: 'fixed',
+  top: 0,
+  left: 0,
 };
 
 class FocusLock extends Component {


### PR DESCRIPTION
When the focus guards steal focus, the browser* will automatically move the focused item into the viewport. Depending on how your modals are mounted, the focus guard could actually be somewhere in the middle (or even off the edges) of the viewport. Thus, when the focus guard is focused on, the content of the window appears offset.

This fixes the focus guard to the top left of the viewport so that the browser will never autoscroll even when the guards take focus.

*Actually only chrome does this