### PR TITLE
Reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,13 @@
 node_modules/
 npm-debug.log
+yarn.lock
 .DS_Store
+.babelrc
+.eslintrc
+.npmignore
+.gitignore
+circle.yml
+stroies/
+.storybook/
+_tests/
+src/


### PR DESCRIPTION
A lot of users worry about `node_modules` size. This small fix reduces unnecessary tests files from npm package.

@theKashey BTW, all PostCSS and Logux packages do the same.