### PR TITLE
Fix Jest support

### DIFF
--- a/src/Trap.js
+++ b/src/Trap.js
@@ -17,7 +17,7 @@ const activateTrap = () => {
         onActivation();
         result = moveFocusInside(observed, lastActiveFocus);
       }
-      lastActiveFocus = document.activeElement;
+      lastActiveFocus = document && document.activeElement;
     }
   }
   return result;


### PR DESCRIPTION
Jest uses JSDom but by some reason without this fix I get:

```
/home/ai/Dev/amplifr-front/node_modules/react-focus-lock/dist/Trap.js:46
      lastActiveFocus = document.activeElement;
                                 ^

TypeError: Cannot read property 'activeElement' of undefined
    at Immediate.activateTrap (/home/ai/Dev/amplifr-front/node_modules/react-focus-lock/dist/Trap.js:46:34)
    at runCallback (timers.js:773:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate [as _immediateCallback] (timers.js:711:5)
```