### PR TITLE
Fix Jest support

### DIFF
--- a/src/Trap.js
+++ b/src/Trap.js
@@ -4,7 +4,7 @@ import withSideEffect from 'react-side-effect';
 import moveFocusInside, { focusInside } from 'focus-lock';
 import { deferAction } from './util';
 
-const focusOnBody = () => document.activeElement !== document.body;
+const focusOnBody = () => document && document.activeElement !== document.body;
 
 let lastActiveTrap = 0;
 let lastActiveFocus = null;


### PR DESCRIPTION
In Jest with `allowTextSelection` I am getting:

```
/home/ai/Dev/amplifr-front/node_modules/react-focus-lock/dist/Trap.js:28
  return document.activeElement !== document.body;
                  ^

TypeError: Cannot read property 'activeElement' of undefined
    at focusOnBody (/home/ai/Dev/amplifr-front/node_modules/react-focus-lock/dist/Trap.js:28:19)
    at Immediate.activateTrap (/home/ai/Dev/amplifr-front/node_modules/react-focus-lock/dist/Trap.js:41:32)
    at runCallback (timers.js:773:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate [as _immediateCallback] (timers.js:711:5)
```

This PR fixes it @theKashey 