### PR TITLE
Add life-cycle hooks

### DIFF
--- a/react-focus-lock.d.ts
+++ b/react-focus-lock.d.ts
@@ -1,89 +1,105 @@
 declare module 'react-focus-lock' {
-    import * as React from 'react';
+  import * as React from 'react';
 
-    interface Props {
-        disabled?: boolean;
-
-        /**
-         * will return focus to the previous position on trap disable.
-         */
-        returnFocus?: boolean;
-
-        /**
-         * @deprecated Use persistentFocus=false instead
-         * enables(or disables) text selection. This also allows not to have ANY focus.
-         */
-        allowTextSelection?: boolean;
-
-        /**
-         * enables of disables "sticky" behavior, when any focusable element shall be focused.
-         * This disallow any text selection on the page.
-         * @default false
-         */
-        persistentFocus?: boolean;
-
-        /**
-         * enables or disables autoFocusing feature.
-         * If enabled - will move focus inside Lock, selecting the first or autoFocusable element
-         * If disable - will blur any focus on Lock activation.
-         * @default true
-         */
-        autoFocus?: boolean;
-
-        /**
-         * disables hidden inputs before and after the lock.
-         */
-        noFocusGuards?: boolean;
-        
-        /**
-         * named focus group for focus scattering aka combined lock targets
-         */
-        group?: string;
-
-        className?: string;
-
-         /**
-          * Component to use, defaults to 'div'
-          */
-        as?: React.ReactType,
-        lockProps?: { [key:string]: any },
-
-        /**
-         * Controls focus lock working areas. Lock will silently ignore all the events from `not allowed` areas
-         * @param activeElement
-         * @returns {Boolean} true if focus lock should handle activeElement, false if not
-         */
-        whiteList?: (activeElement: HTMLElement) => boolean;
-
-        children: React.ReactNode;
-    }
-
-    interface AutoFocusProps {
-        children: React.ReactNode;
-        className?: string;
-    }
-
-    interface FreeFocusProps {
-        className?: string;
-    }
+  interface Props {
+    disabled?: boolean;
 
     /**
-     * Traps Focus inside a Lock
+     * will return focus to the previous position on trap disable.
      */
-    export default class ReactFocusLock extends React.Component<Props> {}
+    returnFocus?: boolean;
 
     /**
-     * Autofocus on children on Lock activation
+     * @deprecated Use persistentFocus=false instead
+     * enables(or disables) text selection. This also allows not to have ANY focus.
      */
-    export class AutoFocusInside extends React.Component<AutoFocusProps> {}
+    allowTextSelection?: boolean;
 
     /**
-     * Autofocus on children
+     * enables of disables "sticky" behavior, when any focusable element shall be focused.
+     * This disallow any text selection on the page.
+     * @default false
      */
-    export class MoveFocusInside extends React.Component<AutoFocusProps> {}
+    persistentFocus?: boolean;
 
     /**
-     * Allow free focus inside on children
+     * enables or disables autoFocusing feature.
+     * If enabled - will move focus inside Lock, selecting the first or autoFocusable element
+     * If disable - will blur any focus on Lock activation.
+     * @default true
      */
-    export class FreeFocusInside extends React.Component<FreeFocusProps> {}
+    autoFocus?: boolean;
+
+    /**
+     * disables hidden inputs before and after the lock.
+     */
+    noFocusGuards?: boolean;
+
+    /**
+     * named focus group for focus scattering aka combined lock targets
+     */
+    group?: string;
+
+    className?: string;
+
+    /**
+     * life-cycle hook, called on lock activation
+     * @param node the observed node
+     */
+    onActivation?(node: HTMLElement): void;
+
+    /**
+     * life-cycle hook, called on deactivation
+     * @param node the observed node
+     */
+    onDeactivation?(node: HTMLElement): void;
+
+    /**
+     * Component to use, defaults to 'div'
+     */
+    as?: React.ReactType,
+    lockProps?: { [key: string]: any },
+
+    /**
+     * Controls focus lock working areas. Lock will silently ignore all the events from `not allowed` areas
+     * @param activeElement
+     * @returns {Boolean} true if focus lock should handle activeElement, false if not
+     */
+    whiteList?: (activeElement: HTMLElement) => boolean;
+
+    children: React.ReactNode;
+  }
+
+  interface AutoFocusProps {
+    children: React.ReactNode;
+    className?: string;
+  }
+
+  interface FreeFocusProps {
+    className?: string;
+  }
+
+  /**
+   * Traps Focus inside a Lock
+   */
+  export default class ReactFocusLock extends React.Component<Props> {
+  }
+
+  /**
+   * Autofocus on children on Lock activation
+   */
+  export class AutoFocusInside extends React.Component<AutoFocusProps> {
+  }
+
+  /**
+   * Autofocus on children
+   */
+  export class MoveFocusInside extends React.Component<AutoFocusProps> {
+  }
+
+  /**
+   * Allow free focus inside on children
+   */
+  export class FreeFocusInside extends React.Component<FreeFocusProps> {
+  }
 }

--- a/src/Trap.js
+++ b/src/Trap.js
@@ -32,7 +32,7 @@ const focusIsPortaledPair = element => (
 const activateTrap = () => {
   let result = false;
   if (lastActiveTrap) {
-    const { observed, onActivation, persistentFocus, autoFocus } = lastActiveTrap;
+    const { observed, persistentFocus, autoFocus } = lastActiveTrap;
     const workingNode = observed || (lastPortaledElement && lastPortaledElement.portaledElement);
     const activeElement = document && document.activeElement;
 
@@ -45,7 +45,6 @@ const activateTrap = () => {
             focusIsPortaledPair(activeElement, workingNode)
           )
         ) {
-          onActivation();
           if (document && !lastActiveFocus && activeElement && !autoFocus) {
             activeElement.blur();
             document.body.focus();
@@ -116,9 +115,20 @@ function handleStateChangeOnClient(trap) {
     attachHandler();
   }
 
+  const lastTrap = lastActiveTrap;
+  const sameTrap = lastTrap && trap && trap.onActivation === lastTrap.onActivation;
+
   lastActiveTrap = trap;
+
+  if (lastTrap && !sameTrap) {
+    lastTrap.onDeactivation();
+  }
+
   if (trap) {
     lastActiveFocus = null;
+    if (!sameTrap || lastTrap.observed !== trap.observed) {
+      trap.onActivation();
+    }
     activateTrap(true);
     deferAction(activateTrap);
   } else {


### PR DESCRIPTION
- simplifying all the things
- exposing onActivation and onDeactivation hooks, called right before trap activation, and right after (not repeatable using didMount/willUnmount)