### PR TITLE
update focus-lock dep to avoid array.find issue in ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "homepage": "https://github.com/theKashey/react-focus-lock#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "focus-lock": "^0.6.4",
+    "focus-lock": "^0.6.5",
     "prop-types": "^15.6.2",
     "react-clientside-effect": "^1.2.1",
     "use-sidecar": "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6852,15 +6852,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.6.3:
+focus-lock@^0.6.3, focus-lock@^0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
   integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
-
-focus-lock@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.4.tgz#066af3ed5875d85745ab45ef4fbbb43e8a73514a"
-  integrity sha512-+waElh6m7dbNmEabXQIblZjJMIRQOoHMNqB8RZkyemK+vN1XQ9uHLi740DVwTcK5fzAq3g+tBglLjIqUDHX/Og==
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
focus-lock version 0.6.4 makes use of `array.find`, which is stopping things from working in IE11