### PR TITLE
feat: use forwardRef, and allow custom as prop

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -19,7 +19,7 @@
   },
   {
     "path": "dist/es2015/index.js",
-    "limit": "4 KB",
+    "limit": "4.1 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,7 +1,7 @@
 [
   {
     "path": "dist/cjs/UI.js",
-    "limit": "1.8 KB",
+    "limit": "2 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",

--- a/UI/UI.d.ts
+++ b/UI/UI.d.ts
@@ -4,10 +4,9 @@ import {ReactFocusLockProps, AutoFocusProps, FreeFocusProps, InFocusGuardProps} 
 /**
  * Traps Focus inside a Lock
  */
-export default class ReactFocusLock extends React.Component<ReactFocusLockProps & {
-  sideCar: React.SFC<any>
-}> {
-}
+declare const ReactFocusLock:React.FC<ReactFocusLockProps & {sideCar: React.SFC<any>}>;
+
+export default ReactFocusLock;
 
 /**
  * Autofocus on children on Lock activation

--- a/_tests/FocusLock.spec.js
+++ b/_tests/FocusLock.spec.js
@@ -79,6 +79,18 @@ describe('react-focus-lock', () => {
       expect(inner.current.innerHTML).to.include('Button 2');
     });
 
+    it('should work with as prop', () => {
+      const inner = React.createRef();
+      const Comp = React.forwardRef((_, ref) => <button ref={ref}>t2 - Button 2</button>);
+      mount(
+        <div>
+          <button >t1 - Button 1</button>
+          <FocusLock as={Comp} ref={inner}/>
+        </div>
+      );
+      expect(inner.current).to.be.equal(document.activeElement);
+      expect(document.activeElement.innerHTML).to.include('Button 2');
+    });
 
     it('Should not focus on inputs', () => {
       const wrapper = mount((
@@ -1070,7 +1082,7 @@ describe('react-focus-lock', () => {
       });
     });
 
-    describe('Hooks',  () => {
+    describe('Hooks', () => {
       it('onActivation/Deactivation', () => {
         const onActivation = sinon.spy();
         const onDeactivation = sinon.spy();

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -62,7 +62,7 @@ export interface ReactFocusLockProps<ChildrenType = React.ReactNode, LockProps=R
   as?: string | React.ElementType<LockProps & {children: ChildrenType}>,
   lockProps?: LockProps,
 
-  ref: Ref<HTMLElement>;
+  ref?: Ref<HTMLElement>;
 
   /**
    * Controls focus lock working areas. Lock will silently ignore all the events from `not allowed` areas

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import {Ref} from "react";
 
-export interface ReactFocusLockProps {
+export interface ReactFocusLockProps<ChildrenType = React.ReactNode, LockProps=Record<string, any>> {
   disabled?: boolean;
 
   /**
@@ -58,8 +59,10 @@ export interface ReactFocusLockProps {
   /**
    * Component to use, defaults to 'div'
    */
-  as?: React.ReactType,
-  lockProps?: { [key: string]: any },
+  as?: string | React.ElementType<LockProps & {children: ChildrenType}>,
+  lockProps?: LockProps,
+
+  ref: Ref<HTMLElement>;
 
   /**
    * Controls focus lock working areas. Lock will silently ignore all the events from `not allowed` areas
@@ -73,7 +76,7 @@ export interface ReactFocusLockProps {
    */
   shards?: Array<React.RefObject<any> | HTMLElement>;
 
-  children: React.ReactNode;
+  children?: ChildrenType;
 }
 
 export interface AutoFocusProps {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "focus-lock": "^0.6.5",
     "prop-types": "^15.6.2",
     "react-clientside-effect": "^1.2.2",
+    "use-callback-ref": "^1.1.0",
     "use-sidecar": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "focus-lock": "^0.6.5",
     "prop-types": "^15.6.2",
     "react-clientside-effect": "^1.2.2",
-    "use-callback-ref": "^1.1.0",
+    "use-callback-ref": "^1.2.1",
     "use-sidecar": "^1.0.1"
   }
 }

--- a/react-focus-lock.d.ts
+++ b/react-focus-lock.d.ts
@@ -4,8 +4,9 @@ import {ReactFocusLockProps, AutoFocusProps, FreeFocusProps, InFocusGuardProps} 
 /**
  * Traps Focus inside a Lock
  */
-export default class ReactFocusLock extends React.Component<ReactFocusLockProps> {
-}
+declare const ReactFocusLock:React.FC<ReactFocusLockProps>;
+
+export default ReactFocusLock;
 
 /**
  * Autofocus on children on Lock activation

--- a/src/Combination.js
+++ b/src/Combination.js
@@ -11,12 +11,13 @@ const RequireSideCar = (props) => {
 };
 */
 
-const FocusLockCombination = props => (
+const FocusLockCombination = React.forwardRef((props, ref) => (
   <FocusLockUI
     sideCar={FocusTrap}
+    ref={ref}
     {...props}
   />
-);
+));
 
 const { sideCar, ...propTypes } = FocusLockUI.propTypes || {};
 

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -117,7 +117,7 @@ const FocusLock = React.forwardRef((props, parentRef) => {
   const hasLeadingGuards = noFocusGuards !== true;
   const hasTailingGuards = hasLeadingGuards && (noFocusGuards !== 'tail');
 
-  const mergedRef = useMergeRefs([parentRef, setObserveNode])
+  const mergedRef = useMergeRefs([parentRef, setObserveNode]);
 
   return (
     <React.Fragment>

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -3,7 +3,8 @@ import {
   node, bool, string, any, arrayOf, oneOfType, object, func,
 } from 'prop-types';
 import * as constants from 'focus-lock/constants';
-import { mergeRefs } from 'use-callback-ref';
+import { useMergeRefs } from 'use-callback-ref';
+
 import { hiddenGuard } from './FocusGuard';
 import { mediumFocus, mediumBlur, mediumSidecar } from './medium';
 
@@ -116,6 +117,8 @@ const FocusLock = React.forwardRef((props, parentRef) => {
   const hasLeadingGuards = noFocusGuards !== true;
   const hasTailingGuards = hasLeadingGuards && (noFocusGuards !== 'tail');
 
+  const mergedRef = useMergeRefs([parentRef, setObserveNode])
+
   return (
     <React.Fragment>
       {hasLeadingGuards && [
@@ -138,7 +141,7 @@ const FocusLock = React.forwardRef((props, parentRef) => {
         />
       )}
       <Container
-        ref={mergeRefs([parentRef, setObserveNode])}
+        ref={mergedRef}
         {...lockProps}
         className={className}
         onBlur={onBlur}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14989,10 +14989,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-callback-ref@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.1.0.tgz#e41d2b29aea8a568a6dbefe0af56155eac1b6884"
-  integrity sha512-a2j1dVM9UTxdIfZjbdhcD8nCDMDBkTp9rFasSBj3QPcVclYdpKbmLzqLddH3R6WuOff9W6Xo50VedPoVNu8z8A==
+use-callback-ref@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
+  integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
 
 use-sidecar@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14989,6 +14989,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-callback-ref@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.1.0.tgz#e41d2b29aea8a568a6dbefe0af56155eac1b6884"
+  integrity sha512-a2j1dVM9UTxdIfZjbdhcD8nCDMDBkTp9rFasSBj3QPcVclYdpKbmLzqLddH3R6WuOff9W6Xo50VedPoVNu8z8A==
+
 use-sidecar@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.1.tgz#75c7a5fdacc14bd3ab64992c638e45a396ad2fad"


### PR DESCRIPTION
Allow ref forwarding, as well as refactor how components are composed inside.

Fixes: #88, #85

Breaks: #85 (ref become an object)