### PR TITLE
fix: avoid crash on IE

### DIFF
--- a/src/Trap.js
+++ b/src/Trap.js
@@ -95,7 +95,10 @@ const activateTrap = () => {
             )
           ) {
             if (document && !lastActiveFocus && activeElement && !autoFocus) {
-              activeElement.blur();
+              // Check if blur() exists, which is missing on certain elements on IE
+              if (activeElement.blur) {
+                activeElement.blur();
+              }
               document.body.focus();
             } else {
               result = moveFocusInside(workingArea, lastActiveFocus);


### PR DESCRIPTION
Avoid crash on IE. Only focusable elements have a blur() function on IE, so we can sometimes crash here without a check.