### PR TITLE
Provide names for FocusLock components

### DIFF
--- a/src/Combination.js
+++ b/src/Combination.js
@@ -11,13 +11,15 @@ const RequireSideCar = (props) => {
 };
 */
 
-const FocusLockCombination = React.forwardRef((props, ref) => (
-  <FocusLockUI
-    sideCar={FocusTrap}
-    ref={ref}
-    {...props}
-  />
-));
+const FocusLockCombination = React.forwardRef(function FocusLockUICombination(props, ref) {
+  return (
+    <FocusLockUI
+      sideCar={FocusTrap}
+      ref={ref}
+      {...props}
+    />
+  )
+});
 
 const { sideCar, ...propTypes } = FocusLockUI.propTypes || {};
 

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -10,7 +10,7 @@ import { mediumFocus, mediumBlur, mediumSidecar } from './medium';
 
 const emptyArray = [];
 
-const FocusLock = React.forwardRef((props, parentRef) => {
+const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
   const [realObserved, setObserved] = React.useState();
   const observed = React.useRef();
   const isActive = React.useRef(false);


### PR DESCRIPTION
#102 hoisted a problem, that all FocusLock components are just "ForwardRef".
Easy to fix