### PR TITLE
fix: do not change focused element when `autoFocus` is `false`

### DIFF
--- a/_tests/FocusLock.spec.js
+++ b/_tests/FocusLock.spec.js
@@ -317,29 +317,7 @@ d-action
       // }, 10);
     });
 
-    it('Should blur focus on inputs, when autoFocus is false', (done) => {
-      const wrapper = mount(<div>
-        <div>
-          text
-          <button className="action1">action1</button>
-          text
-        </div>
-        <FocusLock autoFocus={false}>
-          <div>
-            text
-            <button className="action2">1-action2</button>
-            <button className="action2">2-action2</button>
-            text
-          </div>
-        </FocusLock>
-      </div>);
-      setTimeout(() => {
-        expect(document.activeElement).to.be.equal(document.body);
-        done();
-      }, 10);
-    });
-
-    it('Should blur focus on inputs, when autoFocus is false', (done) => {
+    it('Should not blur focus on inputs, when autoFocus is false', (done) => {
       const wrapper = mount(<div>
         <div>
           text
@@ -358,7 +336,8 @@ d-action
       wrapper.find('.action1').getDOMNode().focus();
       expect(document.activeElement.innerHTML).to.be.equal('action1');
       setTimeout(() => {
-        expect(document.activeElement).to.be.equal(document.body);
+        expect(document.activeElement).to.not.be.equal(document.body);
+        expect(document.activeElement.innerHTML).to.be.equal('1-action2');
         done();
       }, 10);
     });

--- a/src/Trap.js
+++ b/src/Trap.js
@@ -94,13 +94,7 @@ const activateTrap = () => {
               || focusIsPortaledPair(activeElement, workingNode)
             )
           ) {
-            if (document && !lastActiveFocus && activeElement && !autoFocus) {
-              // Check if blur() exists, which is missing on certain elements on IE
-              if (activeElement.blur) {
-                activeElement.blur();
-              }
-              document.body.focus();
-            } else {
+            if (!document || lastActiveFocus || !activeElement || autoFocus) {
               result = moveFocusInside(workingArea, lastActiveFocus);
               lastPortaledElement = {};
             }


### PR DESCRIPTION
Fixes #113