### PR TITLE
Remove positive tabIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ I've got a good [article about focus management, dialogs and  WAI-ARIA](https://
   - `whiteList=fn` you could _whitelist_ locations FocusLock should carry about. Everything outside it will ignore. For example - any modals.
   - `as='div'` if you need to change internal `div` element, to any other. Use ref forwarding to give FocusLock the node to work with.
   - `lockProps={}` to pass any extra props (except className) to the internal wrapper.
-  - `maxTabIndex={0}` to remove positive indices. This allows for better accessibility compliance, but removes compatibility with apps that use positive indices.
+  - `usePositiveIndices` to maintain a focus lock when elements exterior to the focus lock have a tabIndex greater than 0.
 
 ### Focusing in OSX (Safari/Firefox) is strange!
 By default `tabbing` in OSX `sees` only controls, but not links or anything else `tabbable`. This is system settings, and Safari/Firefox obey.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ I've got a good [article about focus management, dialogs and  WAI-ARIA](https://
   - `whiteList=fn` you could _whitelist_ locations FocusLock should carry about. Everything outside it will ignore. For example - any modals.
   - `as='div'` if you need to change internal `div` element, to any other. Use ref forwarding to give FocusLock the node to work with.
   - `lockProps={}` to pass any extra props (except className) to the internal wrapper.
+  - `maxTabIndex={0}` to remove positive indices. This allows for better accessibility compliance, but removes compatibility with apps that use positive indices.
 
 ### Focusing in OSX (Safari/Firefox) is strange!
 By default `tabbing` in OSX `sees` only controls, but not links or anything else `tabbable`. This is system settings, and Safari/Firefox obey.

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  node, bool, string, any, arrayOf, oneOfType, object, func,
+  node, bool, string, any, arrayOf, oneOfType, object, func, number,
 } from 'prop-types';
 import * as constants from 'focus-lock/constants';
 import {useMergeRefs} from 'use-callback-ref';
@@ -28,6 +28,7 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
     group,
     className,
     whiteList,
+    maxTabIndex = 1,
     shards = emptyArray,
     as: Container = 'div',
     lockProps: containerProps = {},
@@ -136,7 +137,7 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
     <React.Fragment>
       {hasLeadingGuards && [
         <div key="guard-first" data-focus-guard tabIndex={disabled ? -1 : 0} style={hiddenGuard}/>, // nearest focus guard
-        <div key="guard-nearest" data-focus-guard tabIndex={disabled ? -1 : 1} style={hiddenGuard}/>, // first tabbed element guard
+        <div key="guard-nearest" data-focus-guard tabIndex={disabled ? -1 : maxTabIndex} style={hiddenGuard}/>, // first tabbed element guard
       ]}
       {!disabled && (
         <SideCar
@@ -176,6 +177,7 @@ FocusLock.propTypes = {
   disabled: bool,
   returnFocus: oneOfType([bool, object]),
   noFocusGuards: bool,
+  maxTabIndex: number,
 
   allowTextSelection: bool,
   autoFocus: bool,
@@ -210,6 +212,7 @@ FocusLock.defaultProps = {
   className: undefined,
   whiteList: undefined,
   shards: undefined,
+  maxTabIndex: 1,
   as: 'div',
   lockProps: {},
 

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  node, bool, string, any, arrayOf, oneOfType, object, func, number,
+  node, bool, string, any, arrayOf, oneOfType, object, func,
 } from 'prop-types';
 import * as constants from 'focus-lock/constants';
 import {useMergeRefs} from 'use-callback-ref';
@@ -28,7 +28,7 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
     group,
     className,
     whiteList,
-    maxTabIndex = 1,
+    usePositiveIndices,
     shards = emptyArray,
     as: Container = 'div',
     lockProps: containerProps = {},
@@ -39,6 +39,8 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
     onActivation: onActivationCallback,
     onDeactivation: onDeactivationCallback,
   } = props;
+
+  const maxTabIndex = usePositiveIndices ? 1 : 0;
 
   const [id] = React.useState({});
 
@@ -177,7 +179,7 @@ FocusLock.propTypes = {
   disabled: bool,
   returnFocus: oneOfType([bool, object]),
   noFocusGuards: bool,
-  maxTabIndex: number,
+  usePositiveIndices: bool,
 
   allowTextSelection: bool,
   autoFocus: bool,
@@ -207,12 +209,12 @@ FocusLock.defaultProps = {
   autoFocus: true,
   persistentFocus: false,
   crossFrame: true,
+  usePositiveIndices: undefined,
   allowTextSelection: undefined,
   group: undefined,
   className: undefined,
   whiteList: undefined,
   shards: undefined,
-  maxTabIndex: 1,
   as: 'div',
   lockProps: {},
 


### PR DESCRIPTION
A positive `tabIndex` has become a significant accessibility flag. The axe devtools bot flags any `tabIndex={1}` on your page as a serious error. Even though [this](https://github.com/theKashey/react-focus-lock/blob/4ef6569cd8be56b592a08ad951e84af4d0beaad6/src/Lock.js#L139) element with a `tabIndex` of `1` isn't really part of the direct user experience, it's best to get rid of any positive indices on your page. 

I found that when setting `noFocusGuards`, things worked fine when developing your storybook examples, but on my own setup this popped the focus out of the lock. 

As I understand the issue, the `tabIndex` value of `1` here handles cases when devs have other elements on their pages with a positive index.

It seems to me there would be two options:
- a backwards compatible prop (e.g. `maxTabIndex={0}`) that would override the current positive index 
- replacing the current positive index to `0` and allowing users with other positive indices on their sites to set a prop that would override it to `1`

I believe the latter is a cleaner api and allows for default accessibility compliance, but the former offers backwards compatibility for devs who are using positive indices on their pages.

This PR has two commits for each option, respectively.