### PR TITLE
Update InFocusGuard to make children prop optional

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -114,5 +114,5 @@ export interface FreeFocusProps {
 }
 
 export interface InFocusGuardProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }


### PR DESCRIPTION
The `children` property is optional in the `InFocusGuard` component. This updates the typescript interface so that it doesn't complain about children being required when we use `<InFocusGuard />`.