### PR TITLE
change default property crossFrame to false by default

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -44,7 +44,7 @@ export interface ReactFocusLockProps<ChildrenType = React.ReactNode, LockProps =
    * enables aggressive focus capturing within iframes
    * - once disabled allows focus to move outside of iframe, if enabled inside iframe
    * - once enabled keep focus in the lock, no matter where lock is active (default)
-   * @default true
+   * @default false
    */
   crossFrame?: boolean;
 

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -215,7 +215,7 @@ FocusLock.defaultProps = {
   noFocusGuards: false,
   autoFocus: true,
   persistentFocus: false,
-  crossFrame: true,
+  crossFrame: false,
   hasPositiveIndices: undefined,
   allowTextSelection: undefined,
   group: undefined,


### PR DESCRIPTION
Depends on issue https://github.com/theKashey/react-focus-lock/issues/218 and https://github.com/theKashey/react-focus-lock/issues/104#issuecomment-734332075 comment
