### PR TITLE
Remove default props in AutoFocusInside to fix react 18 warning

### DIFF
--- a/src/AutoFocusInside.js
+++ b/src/AutoFocusInside.js
@@ -1,9 +1,10 @@
+/* eslint-disable react/require-default-props */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import * as constants from 'focus-lock/constants';
 import { inlineProp } from './util';
 
-const AutoFocusInside = ({ disabled, children, className }) => (
+const AutoFocusInside = ({ disabled = false, children, className = undefined }) => (
   <div {...inlineProp(constants.FOCUS_AUTO, !disabled)} className={className}>
     {children}
   </div>
@@ -13,11 +14,6 @@ AutoFocusInside.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   className: PropTypes.string,
-};
-
-AutoFocusInside.defaultProps = {
-  disabled: false,
-  className: undefined,
 };
 
 export default AutoFocusInside;


### PR DESCRIPTION
Fixes a warning with react 18. See this issue.
https://github.com/theKashey/react-focus-lock/issues/239