### PR TITLE
fix: correct crossframe behavior for Safari, fixes #249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.9.4](https://github.com/theKashey/react-focus-lock/compare/v2.9.3...v2.9.4) (2023-02-16)
+
+
+### Bug Fixes
+
+* update focus-lock to prevent error when accessing cross-origin frames. fixes [#241](https://github.com/theKashey/react-focus-lock/issues/241) ([6633d2b](https://github.com/theKashey/react-focus-lock/commit/6633d2bed7f61fe1b6ca9a573331568bbd0b63af))
+
+
+
 ## [2.9.3](https://github.com/theKashey/react-focus-lock/compare/v2.9.2...v2.9.3) (2023-01-28)
 
 

--- a/src/Trap.js
+++ b/src/Trap.js
@@ -182,9 +182,9 @@ FocusTrap.propTypes = {
 const onWindowBlur = () => {
   focusWasOutsideWindow = 'just';
   // using setTimeout to set  this variable after React/sidecar reaction
-  setTimeout(() => {
+  deferAction(() => {
     focusWasOutsideWindow = 'meanwhile';
-  }, 0);
+  });
 };
 
 const attachHandler = () => {

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,5 @@
 export function deferAction(action) {
-  // Hidding setImmediate from Webpack to avoid inserting polyfill
-  const { setImmediate } = window;
-  if (typeof setImmediate !== 'undefined') {
-    setImmediate(action);
-  } else {
-    setTimeout(action, 1);
-  }
+  setTimeout(action, 1);
 }
 
 export const inlineProp = (name, value) => {


### PR DESCRIPTION
Two actions are not in sync. As a solution:
- remove setImmediate, it does not really exists in browsers, but makes tests happy
- use the same defer helper for both cases.