### PR TITLE
Replace defaultProps with default function parameters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     // Turn off https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
     "react/jsx-filename-extension": 0,
     "react/forbid-prop-types" : 0,
+    "react/require-default-props": 0,
 
     // Turn off https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
     "import/no-named-as-default-member": 0,

--- a/src/AutoFocusInside.js
+++ b/src/AutoFocusInside.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import * as constants from 'focus-lock/constants';

--- a/src/FocusGuard.js
+++ b/src/FocusGuard.js
@@ -11,20 +11,16 @@ export const hiddenGuard = {
   left: '1px',
 };
 
-const InFocusGuard = ({ children }) => (
+const InFocusGuard = ({ children = null }) => (
   <React.Fragment>
     <div key="guard-first" data-focus-guard data-focus-auto-guard style={hiddenGuard} />
     {children}
     {children && <div key="guard-last" data-focus-guard data-focus-auto-guard style={hiddenGuard} />}
   </React.Fragment>
 );
+
 InFocusGuard.propTypes = {
   children: PropTypes.node,
 };
-
-InFocusGuard.defaultProps = {
-  children: null,
-};
-
 
 export default InFocusGuard;

--- a/src/FreeFocusInside.js
+++ b/src/FreeFocusInside.js
@@ -14,8 +14,4 @@ FreeFocusInside.propTypes = {
   className: PropTypes.string,
 };
 
-FreeFocusInside.defaultProps = {
-  className: undefined,
-};
-
 export default FreeFocusInside;

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -19,11 +19,11 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
 
   const {
     children,
-    disabled,
-    noFocusGuards,
-    persistentFocus,
-    crossFrame,
-    autoFocus,
+    disabled = false,
+    noFocusGuards = false,
+    persistentFocus = false,
+    crossFrame = true,
+    autoFocus = true,
     allowTextSelection,
     group,
     className,
@@ -34,7 +34,7 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
     lockProps: containerProps = {},
     sideCar: SideCar,
 
-    returnFocus: shouldReturnFocus,
+    returnFocus: shouldReturnFocus = false,
     focusOptions,
 
     onActivation: onActivationCallback,
@@ -206,28 +206,6 @@ FocusLock.propTypes = {
   onDeactivation: func,
 
   sideCar: any.isRequired,
-};
-
-FocusLock.defaultProps = {
-  children: undefined,
-  disabled: false,
-  returnFocus: false,
-  focusOptions: undefined,
-  noFocusGuards: false,
-  autoFocus: true,
-  persistentFocus: false,
-  crossFrame: true,
-  hasPositiveIndices: undefined,
-  allowTextSelection: undefined,
-  group: undefined,
-  className: undefined,
-  whiteList: undefined,
-  shards: undefined,
-  as: 'div',
-  lockProps: {},
-
-  onActivation: undefined,
-  onDeactivation: undefined,
 };
 
 export default FocusLock;

--- a/src/MoveFocusInside.js
+++ b/src/MoveFocusInside.js
@@ -21,7 +21,7 @@ export const useFocusInside = (observedRef) => {
   }, [observedRef]);
 };
 
-function MoveFocusInside({ disabled: isDisabled, className, children }) {
+function MoveFocusInside({ disabled: isDisabled = false, className, children }) {
   const ref = React.useRef(null);
   useFocusInside(isDisabled ? undefined : ref);
 
@@ -40,11 +40,6 @@ MoveFocusInside.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   className: PropTypes.string,
-};
-
-MoveFocusInside.defaultProps = {
-  disabled: false,
-  className: undefined,
 };
 
 export default MoveFocusInside;


### PR DESCRIPTION
As default props on function components are going to be deprecated in future release in favor of default function parameters (see: https://github.com/facebook/react/pull/16210), I followed the recommendation. Note that default function parameters were actually already used (see `lockProps` for example)!