### PR TITLE
Bump focus-lock to 1.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "homepage": "https://github.com/theKashey/react-focus-lock#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "focus-lock": "^1.3.2",
+    "focus-lock": "^1.3.5",
     "prop-types": "^15.6.2",
     "react-clientside-effect": "^1.2.6",
     "use-callback-ref": "^1.3.0",


### PR DESCRIPTION
Hi! 

I'm using react-focus-lock in a project and I'm seeing this bug => https://github.com/theKashey/focus-lock/issues/68
It would be create if you could bump version.

Thanks in advance! 😊