### PR TITLE
fix: auto-focus in case of activeElement disappearance, fixes #321

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -10,7 +10,7 @@
   },
   {
     "path": "dist/es2015/sidecar.js",
-    "limit": "4.8 KB",
+    "limit": "4.85 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",
@@ -19,7 +19,7 @@
   },
   {
     "path": "dist/es2015/index.js",
-    "limit": "7.1 KB",
+    "limit": "7.2 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,7 +1,7 @@
 [
   {
     "path": "dist/cjs/UI.js",
-    "limit": "3.8 KB",
+    "limit": "3.9 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",
@@ -10,7 +10,7 @@
   },
   {
     "path": "dist/es2015/sidecar.js",
-    "limit": "4.6 KB",
+    "limit": "4.8 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",
@@ -19,7 +19,7 @@
   },
   {
     "path": "dist/es2015/index.js",
-    "limit": "6.9 KB",
+    "limit": "7.1 KB",
     "ignore": [
       "prop-types",
       "@babel/runtime",

--- a/_tests/keep-focus.spec.js
+++ b/_tests/keep-focus.spec.js
@@ -1,20 +1,102 @@
 import React from 'react';
 import {
-  render, screen,
+  render,
 } from '@testing-library/react';
 import { expect } from 'chai';
 import FocusLock from '../src';
+import { deferAction } from '../src/util';
 
-describe('Focus restoration', () => {
+describe('Focus restoration', async () => {
   it('maintains focus on element removal', async () => {
-    render(
+    const { rerender } = render(
       <FocusLock>
-        <button type="button">test</button>
+        <button type="button" key={1}>btn1</button>
       </FocusLock>,
     );
     //
-    expect(document.activeElement).to.be.equal(screen.getByRole('button'));
+    expect(document.activeElement.innerHTML).to.be.equal('btn1');
+
+    rerender(
+      <FocusLock>
+        <button type="button" key={2}>new button</button>
+      </FocusLock>,
+    );
+
+    // wait
+    await new Promise(deferAction);
+
+    expect(document.activeElement.innerHTML).to.be.equal('new button');
   });
 
-  it.todo('selects closes element to restore focus');
+  it('handles disabled elements', async () => {
+    const { rerender } = render(
+      <FocusLock>
+        <button type="button">btn1</button>
+        <button type="button">btn2</button>
+      </FocusLock>,
+    );
+    //
+    expect(document.activeElement.innerHTML).to.be.equal('btn1');
+
+
+    // https://github.com/jsdom/jsdom/issues/3029 - jsdom does trigger blur on disabled
+    document.activeElement.blur();
+    document.body.focus();
+
+    rerender(
+      <FocusLock>
+        <button type="button" disabled>btn1</button>
+        <button type="button">btn2</button>
+      </FocusLock>,
+    );
+
+    // wait
+    await new Promise(deferAction);
+
+    expect(document.activeElement.innerHTML).to.be.equal('btn2');
+  });
+
+  it('moves focus to the nearest element', async () => {
+    render(
+      <FocusLock>
+        <button type="button">btn1</button>
+        <button type="button">btn2</button>
+        <button type="button" id="middle-button">btn3</button>
+        <button type="button">btn4</button>
+        <button type="button">btn5</button>
+      </FocusLock>,
+    );
+    //
+    const middleButton = document.getElementById('middle-button');
+    middleButton.focus();
+    expect(document.activeElement).to.be.equal(middleButton);
+
+    middleButton.parentElement.removeChild(middleButton);
+    // wait
+    await new Promise(deferAction);
+
+    // btn4 "replaces" bnt3 in visual order
+    expect(document.activeElement.innerHTML).to.be.equal('btn4');
+  });
+
+  it('moves focus to the nearest element before', async () => {
+    render(
+      <FocusLock>
+        <button type="button">btn1</button>
+        <button type="button">btn2</button>
+        <button type="button" id="middle-button">btn3</button>
+      </FocusLock>,
+    );
+    //
+    const middleButton = document.getElementById('middle-button');
+    middleButton.focus();
+    expect(document.activeElement).to.be.equal(middleButton);
+
+    middleButton.parentElement.removeChild(middleButton);
+    // wait
+    await new Promise(deferAction);
+
+    // btn2 is just before bnt3
+    expect(document.activeElement.innerHTML).to.be.equal('btn2');
+  });
 });

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -173,6 +173,7 @@ const FocusLock = React.forwardRef(function FocusLockUI(props, parentRef) {
           onDeactivation={onDeactivation}
           returnFocus={returnFocus}
           focusOptions={focusOptions}
+          noFocusGuards={noFocusGuards}
         />
       )}
       <Container

--- a/stories/Iframe.js
+++ b/stories/Iframe.js
@@ -74,9 +74,23 @@ export const IFrame = props => (
       {' '}
       outside
     </div>
+    <hr />
+    <Trap {...props} />
+    <hr />
+
     <Trap {...props}>
-      <iframe src={`/iframe.html?id=focus-lock--codesandbox-example&crossFrame=${props.crossFrame}`} style={{ width: '100%', height: '400px' }} />
+      <iframe
+        src={`/iframe.html?id=focus-lock--codesandbox-example&crossFrame=${props.crossFrame}`}
+        style={{ width: '100%', height: '400px' }}
+      />
+      <iframe
+        src={`/iframe.html?id=focus-lock--codesandbox-example&crossFrame=${props.crossFrame}`}
+        style={{ width: '100%', height: '400px' }}
+      />
     </Trap>
+    <hr />
+    <Trap {...props} />
+    <hr />
     <div style={bg}>
       {' '}
       Inaccessible


### PR DESCRIPTION
- if element is lost, restore focus
- if element is no longer focusable, restore focus

This change adds logic to "blur" event that triggers when focus moves to body.
In this case focus-lock will try to understand _why_ it happened and apply focus-restoration logic if applicable.